### PR TITLE
feat(projects): allow exchange to credits for all supported allocation types

### DIFF
--- a/src/projects/helpers/apiSlice.js
+++ b/src/projects/helpers/apiSlice.js
@@ -229,33 +229,40 @@ const addRequest = (
           exchangeResources[resource.resourceId].questions || [];
   }
 
-  // Add a fake credit-like resource to Maximize requests to enable exchanges.
-  if (!request.usesCredits && resources.length)
-    request.resources.push({
-      allocated: 0,
-      decimalPlaces: 0,
-      exchangeRates: {
-        base: {
-          type: "base",
-          unitCost: 1.0,
+  // Ensure all requests that support exchanges have a credit-like resource.
+  if (
+    exchangeAction &&
+    request.resources.length &&
+    !request.resources.find((res) => res.isCredit)
+  )
+    request.resources.push(
+      exchangeAction.resources.find((res) => res.isCredit) || {
+        allocated: 0,
+        decimalPlaces: 0,
+        exchangeRates: {
+          base: {
+            type: "base",
+            unitCost: 1.0,
+          },
+          current: {
+            type: "base",
+            unitCost: 1.0,
+          },
         },
-        current: {
-          type: "base",
-          unitCost: 1.0,
-        },
+        icon: "credit",
+        isActive: true,
+        isBoolean: false,
+        isCredit: true,
+        isFake: true,
+        name: "Credit Equivalents",
+        requested: 0,
+        requires: [],
+        resourceId: 0,
+        unit: "Credit Equivalents",
+        used: 0,
       },
-      icon: "credit",
-      isActive: true,
-      isBoolean: false,
-      isCredit: true,
-      isFake: true,
-      name: "Credit Equivalents",
-      requested: 0,
-      requires: [],
-      resourceId: 0,
-      unit: "Credit Equivalents",
-      used: 0,
-    });
+    );
+
   state.requests[requestId] = request;
 };
 


### PR DESCRIPTION
This branch makes it possible to exchange resource units for credits in any allocation types that supports exchange/transfer to ACCESS Credits (e.g., Maximize).